### PR TITLE
hw8

### DIFF
--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -83,6 +83,16 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>

--- a/bot/src/main/java/edu/java/bot/BotApplication.java
+++ b/bot/src/main/java/edu/java/bot/BotApplication.java
@@ -1,12 +1,15 @@
 package edu.java.bot;
 
 import edu.java.bot.configuration.ApplicationConfig;
+import edu.java.bot.configuration.KafkaConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.kafka.annotation.EnableKafka;
 
 @SpringBootApplication
-@EnableConfigurationProperties(ApplicationConfig.class)
+@EnableKafka
+@EnableConfigurationProperties({ApplicationConfig.class, KafkaConfiguration.class})
 public class BotApplication {
     public static void main(String[] args) {
         SpringApplication.run(BotApplication.class, args);

--- a/bot/src/main/java/edu/java/bot/CommandLineRunnerImpl.java
+++ b/bot/src/main/java/edu/java/bot/CommandLineRunnerImpl.java
@@ -15,7 +15,7 @@ public class CommandLineRunnerImpl implements CommandLineRunner {
     Logger logger = LogManager.getLogger();
 
     @Autowired
-    public CommandLineRunnerImpl(PenBot penBot, ScrapperClient scrapperClient) {
+    public CommandLineRunnerImpl(PenBot penBot) {
         this.penBot = penBot;
     }
 
@@ -23,21 +23,8 @@ public class CommandLineRunnerImpl implements CommandLineRunner {
 
     @SuppressWarnings("MagicNumber")
     @Override
-    public void run(String... args) throws Exception {
+    public void run(String... args) {
         penBot.start();
-//        Thread.sleep(10000);
-//        scrapperClient.registerChat(1L);
-//        AddLinkRequest linkRequest =
-//            new AddLinkRequest(URI.create(
-//                "https://stackoverflow.com/questions/49132346/spring-rest-controller-string-response"));
-//        scrapperClient.startLinkTracking(1L, linkRequest);
-//        scrapperClient.registerChat(2L);
-//        scrapperClient.registerChat(2L);
-//        scrapperClient.startLinkTracking(2L, linkRequest);
-//        scrapperClient.startLinkTracking(2L, linkRequest);
-//        scrapperClient.stopLinkTracking(2L, new RemoveLinkRequest(linkRequest.link()));
-//        scrapperClient.deleteChat(2L);
-//        scrapperClient.deleteChat(2L);
-//        scrapperClient.stopLinkTracking(2L, new RemoveLinkRequest(linkRequest.link()));
+        logger.info("started");
     }
 }

--- a/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
@@ -29,14 +29,17 @@ public record ApplicationConfig(
     String pattern,
     @NotEmpty
     String notTracked,
-
     @NotEmpty
     String baseUrlScrapper,
 
     @NotEmpty
     String seeUpdate,
     @NotEmpty
-    String deleteWithSecretPhrase
+    String deleteWithSecretPhrase,
+    @NotEmpty
+    String topic,
+    @NotEmpty
+    String id
 ) {
 
 }

--- a/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
@@ -35,11 +35,7 @@ public record ApplicationConfig(
     @NotEmpty
     String seeUpdate,
     @NotEmpty
-    String deleteWithSecretPhrase,
-    @NotEmpty
-    String topic,
-    @NotEmpty
-    String id
+    String deleteWithSecretPhrase
 ) {
 
 }

--- a/bot/src/main/java/edu/java/bot/configuration/ErrorHandler.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ErrorHandler.java
@@ -1,0 +1,25 @@
+package edu.java.bot.configuration;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.kafka.listener.ConsumerAwareListenerErrorHandler;
+import org.springframework.kafka.listener.ListenerExecutionFailedException;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ErrorHandler implements ConsumerAwareListenerErrorHandler {
+    private static final Logger ERROR = LogManager.getLogger();
+
+    @Override
+    public Object handleError(
+        Message<?> message,
+        ListenerExecutionFailedException exception,
+        @NotNull Consumer<?, ?> consumer
+    ) {
+        ERROR.error(message.getPayload().getClass() + exception.getMessage());
+        return null;
+    }
+}

--- a/bot/src/main/java/edu/java/bot/configuration/KafkaConfiguration.java
+++ b/bot/src/main/java/edu/java/bot/configuration/KafkaConfiguration.java
@@ -1,0 +1,33 @@
+package edu.java.bot.configuration;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaConfiguration {
+    private final ApplicationConfig applicationConfig;
+
+    Logger logger = LogManager.getLogger();
+
+    public KafkaConfiguration(ApplicationConfig applicationConfig) {
+        this.applicationConfig = applicationConfig;
+    }
+
+    @Bean
+    public NewTopic topic() {
+        return TopicBuilder.name(applicationConfig.topic())
+            .partitions(2)
+            .replicas(1)
+            .build();
+    }
+
+    @KafkaListener(id = "bot", topics = "topic1")
+    public void listen(String in) {
+        logger.info(in);
+    }
+}

--- a/bot/src/main/java/edu/java/bot/configuration/KafkaConfiguration.java
+++ b/bot/src/main/java/edu/java/bot/configuration/KafkaConfiguration.java
@@ -4,14 +4,22 @@ import edu.java.bot.controller.dto.LinkUpdate;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.DelegatingByTypeSerializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 @ConfigurationProperties("spring.kafka.consumer")
 public record KafkaConfiguration(
@@ -48,6 +56,29 @@ public record KafkaConfiguration(
         factory.setConsumerFactory(consumerFactory);
         factory.setConcurrency(concurrency());
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+
         return factory;
+    }
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:29091");
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props, new StringSerializer(),
+            new DelegatingByTypeSerializer(Map.of(byte[].class, new ByteArraySerializer(),
+                LinkUpdate.class, new JsonSerializer<>()
+            ))
+        );
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplateBot(
+        ProducerFactory<String,
+            Object> producerFactory
+    ) {
+        return new KafkaTemplate<>(producerFactory);
     }
 }

--- a/bot/src/main/java/edu/java/bot/configuration/KafkaConfiguration.java
+++ b/bot/src/main/java/edu/java/bot/configuration/KafkaConfiguration.java
@@ -1,33 +1,53 @@
 package edu.java.bot.configuration;
 
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import edu.java.bot.controller.dto.LinkUpdate;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
 
-@Configuration
-public class KafkaConfiguration {
-    private final ApplicationConfig applicationConfig;
-
-    Logger logger = LogManager.getLogger();
-
-    public KafkaConfiguration(ApplicationConfig applicationConfig) {
-        this.applicationConfig = applicationConfig;
+@ConfigurationProperties("spring.kafka.consumer")
+public record KafkaConfiguration(
+    String bootstrapServers,
+    String groupId,
+    String autoOffsetReset,
+    Integer maxPollIntervalMs,
+    Boolean enableAutoCommit,
+    Integer concurrency,
+    String topic
+) {
+    @Bean
+    public ConsumerFactory<String, LinkUpdate> updateConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset());
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollIntervalMs());
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, enableAutoCommit());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, LinkUpdate.class);
+        return new DefaultKafkaConsumerFactory<>(props);
     }
 
     @Bean
-    public NewTopic topic() {
-        return TopicBuilder.name(applicationConfig.topic())
-            .partitions(2)
-            .replicas(1)
-            .build();
-    }
-
-    @KafkaListener(id = "bot", topics = "topic1")
-    public void listen(String in) {
-        logger.info(in);
+    public ConcurrentKafkaListenerContainerFactory<String, LinkUpdate> updateKafkaListenerContainerFactory(
+        ConsumerFactory<String, LinkUpdate> consumerFactory
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, LinkUpdate> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.setConcurrency(concurrency());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        return factory;
     }
 }

--- a/bot/src/main/java/edu/java/bot/service/UpdateKafkaListener.java
+++ b/bot/src/main/java/edu/java/bot/service/UpdateKafkaListener.java
@@ -32,15 +32,20 @@ public class UpdateKafkaListener {
         @Header(KafkaHeaders.RECEIVED_KEY) String key,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition
     ) {
-        log.info("Received Message from partition {} with key {}: {}", partition, key, linkUpdate);
-        var sendUpdate = new SendUpdate(
-            linkUpdate.url(),
-            linkUpdate.description(),
-            linkUpdate.tgChatIds(),
-            linkUpdate.description()
-        );
-        penBot.processUpdateFromScrapper(sendUpdate);
-        log.info("Done!");
+        try {
+            log.info("Received Message from partition {} with key {}: {}", partition, key, linkUpdate);
+            var sendUpdate = new SendUpdate(
+                linkUpdate.url(),
+                linkUpdate.description(),
+                linkUpdate.tgChatIds(),
+                linkUpdate.description()
+            );
+            penBot.processUpdateFromScrapper(sendUpdate);
+            log.info("Done!");
+        } catch (RuntimeException runtimeException) {
+            log.error(runtimeException.getMessage());
+            listenDlt(linkUpdate);
+        }
     }
 
     @DltHandler

--- a/bot/src/main/java/edu/java/bot/service/UpdateKafkaListener.java
+++ b/bot/src/main/java/edu/java/bot/service/UpdateKafkaListener.java
@@ -1,0 +1,26 @@
+package edu.java.bot.service;
+
+import edu.java.bot.controller.dto.LinkUpdate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class UpdateKafkaListener {
+
+    @KafkaListener(topics = "messages.string",
+                   groupId = "bot",
+                   containerFactory = "updateKafkaListenerContainerFactory",
+                   concurrency = "1")
+    public void listenUpdate(
+        @Payload LinkUpdate message,
+        @Header(KafkaHeaders.RECEIVED_KEY) String key,
+        @Header(KafkaHeaders.RECEIVED_PARTITION) int partition
+    ) {
+        log.info("Received Message from partition {} with key {}: {}", partition, key, message);
+    }
+}

--- a/bot/src/main/java/edu/java/bot/service/UpdateKafkaListener.java
+++ b/bot/src/main/java/edu/java/bot/service/UpdateKafkaListener.java
@@ -2,6 +2,8 @@ package edu.java.bot.service;
 
 import edu.java.bot.controller.dto.LinkUpdate;
 import edu.java.bot.service.model.SendUpdate;
+import java.util.concurrent.CountDownLatch;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -16,6 +18,8 @@ import org.springframework.stereotype.Component;
 public class UpdateKafkaListener {
 
     private final PenBot penBot;
+
+    @Getter private CountDownLatch latch = new CountDownLatch(1);
 
     public UpdateKafkaListener(PenBot penBot) {
         this.penBot = penBot;
@@ -42,6 +46,7 @@ public class UpdateKafkaListener {
             );
             penBot.processUpdateFromScrapper(sendUpdate);
             log.info("Done!");
+            latch.countDown();
         } catch (RuntimeException runtimeException) {
             log.error(runtimeException.getMessage());
             listenDlt(linkUpdate);
@@ -53,5 +58,9 @@ public class UpdateKafkaListener {
         @Payload LinkUpdate linkUpdate
     ) {
         log.info("Received Message : {}", linkUpdate);
+    }
+
+    public void resetLatch() {
+        latch = new CountDownLatch(1);
     }
 }

--- a/bot/src/main/java/edu/java/bot/service/UpdateKafkaListener.java
+++ b/bot/src/main/java/edu/java/bot/service/UpdateKafkaListener.java
@@ -1,6 +1,7 @@
 package edu.java.bot.service;
 
 import edu.java.bot.controller.dto.LinkUpdate;
+import edu.java.bot.service.model.SendUpdate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.KafkaHeaders;
@@ -12,15 +13,29 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class UpdateKafkaListener {
 
+    private final PenBot penBot;
+
+    public UpdateKafkaListener(PenBot penBot) {
+        this.penBot = penBot;
+    }
+
+
     @KafkaListener(topics = "messages.string",
                    groupId = "bot",
                    containerFactory = "updateKafkaListenerContainerFactory",
                    concurrency = "1")
     public void listenUpdate(
-        @Payload LinkUpdate message,
+        @Payload LinkUpdate linkUpdate,
         @Header(KafkaHeaders.RECEIVED_KEY) String key,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition
     ) {
-        log.info("Received Message from partition {} with key {}: {}", partition, key, message);
+        log.info("Received Message from partition {} with key {}: {}", partition, key, linkUpdate);
+        var sendUpdate = new SendUpdate(
+            linkUpdate.url(),
+            linkUpdate.description(),
+            linkUpdate.tgChatIds(),
+            linkUpdate.description());
+        penBot.processUpdateFromScrapper(sendUpdate);
+        log.info("Done!");
     }
 }

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -13,6 +13,8 @@ app:
   baseUrlScrapper: "http://localhost:8080"
   seeUpdate: "Find out new content from source: "
   deleteWithSecretPhrase: "bye"
+  topic: "topic1"
+  id: "bot"
 spring:
   application:
     name: bot

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -13,8 +13,7 @@ app:
   baseUrlScrapper: "http://localhost:8080"
   seeUpdate: "Find out new content from source: "
   deleteWithSecretPhrase: "bye"
-  topic: "topic1"
-  id: "bot"
+
 spring:
   application:
     name: bot
@@ -22,7 +21,15 @@ spring:
     time-zone: UTC
   config:
     import: optional:file:.env[.properties]
-
+  kafka:
+   consumer:
+    bootstrapServers: localhost:29092
+    groupId: bot
+    autoOffsetReset: latest
+    maxPollIntervalMs: 300_000
+    enableAutoCommit: false
+    concurrency: 1
+    topic: "messages.string"
 server:
   port: 8090
 

--- a/bot/src/test/java/edu/java/hw1/ListHandlerTest.java
+++ b/bot/src/test/java/edu/java/hw1/ListHandlerTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -40,30 +41,13 @@ public class ListHandlerTest {
 
     @Mock Message message = new Message();
 
+    @Mock ApplicationConfig applicationConfig;
+
     User user = new User(1L);
 
     UserMessageHandler messageHandler = new UserMessageHandlerImpl();
     com.pengrad.telegrambot.model.Chat chat = mock(com.pengrad.telegrambot.model.Chat.class);
     BotUser botUser = new BotUser(1L, 1L, null, true);
-
-    ApplicationConfig applicationConfig = new ApplicationConfig(
-        "12345",
-        "aa",
-        "1",
-        "1",
-        "1",
-        "1",
-        "Here you are: ",
-        "You have no links being tracked. Print /track to add a link",
-        "1",
-        "1",
-        "1",
-        "",
-        "",
-        ""
-
-    );
-
     @Test
     void appliesListCommand() {
         Chat chat1 = new Chat(
@@ -89,7 +73,7 @@ public class ListHandlerTest {
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.getLinksFromTG(botUser.chatId())).thenReturn(response);
-
+        Mockito.when(applicationConfig.linksHeader()).thenReturn("Here you are: ");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo(
@@ -121,7 +105,7 @@ public class ListHandlerTest {
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.getLinksFromTG(botUser.chatId())).thenReturn(response);
-
+        Mockito.when(applicationConfig.emptyList()).thenReturn("You have no links being tracked. Print /track to add a link");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo(
@@ -143,6 +127,7 @@ public class ListHandlerTest {
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.findChat(message.chat().id())).thenReturn(response);
+        Mockito.when(applicationConfig.register()).thenReturn("aa");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo(

--- a/bot/src/test/java/edu/java/hw1/NoCommandHandlerTest.java
+++ b/bot/src/test/java/edu/java/hw1/NoCommandHandlerTest.java
@@ -95,7 +95,11 @@ public class NoCommandHandlerTest {
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.startLinkTracking(botUser.chatId(), linkRequest))
             .thenReturn(new LinkResponse(1L, URI.create("https://stackoverflow.com/search?q=unsupported%20link")));
-        Mockito.when(applicationConfig.done()).thenReturn("4");
+        Mockito.when(applicationConfig.pattern())
+            .thenReturn(
+                "^(https?://){1}([\\w\\Q$-_+!*'(),%\\E]+\\.)+(\\w{2,63})(:\\d{1,4})?([\\w\\Q/$-_+!*'(),%\\E]+\\.?[\\w\\Q$-_+!*'(),%\\E={0-5}?&.])*/?$"
+            );
+        Mockito.when(applicationConfig.done()).thenReturn("4 ");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo(
@@ -127,7 +131,11 @@ public class NoCommandHandlerTest {
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.stopLinkTracking(botUser.chatId(), linkRequest))
             .thenReturn(new LinkResponse(1L, URI.create("https://stackoverflow.com/search?q=unsupported%20link")));
-        Mockito.when(applicationConfig.done()).thenReturn("4");
+        Mockito.when(applicationConfig.done()).thenReturn("4 ");
+        Mockito.when(applicationConfig.pattern())
+            .thenReturn(
+                "^(https?://){1}([\\w\\Q$-_+!*'(),%\\E]+\\.)+(\\w{2,63})(:\\d{1,4})?([\\w\\Q/$-_+!*'(),%\\E]+\\.?[\\w\\Q$-_+!*'(),%\\E={0-5}?&.])*/?$"
+            );
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo(
@@ -157,6 +165,10 @@ public class NoCommandHandlerTest {
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(applicationConfig.notUnderstand()).thenReturn("sorry");
+        Mockito.when(applicationConfig.pattern())
+            .thenReturn(
+                "^(https?://){1}([\\w\\Q$-_+!*'(),%\\E]+\\.)+(\\w{2,63})(:\\d{1,4})?([\\w\\Q/$-_+!*'(),%\\E]+\\.?[\\w\\Q$-_+!*'(),%\\E={0-5}?&.])*/?$"
+            );
 
         var result = handler.handle(bot, messageHandler, update);
 

--- a/bot/src/test/java/edu/java/hw1/NoCommandHandlerTest.java
+++ b/bot/src/test/java/edu/java/hw1/NoCommandHandlerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -40,30 +41,13 @@ public class NoCommandHandlerTest {
 
     @Mock ScrapperClient scrapperClient;
 
+    @Mock ApplicationConfig applicationConfig;
+
     User user = new User(1L);
 
     UserMessageHandler messageHandler = new UserMessageHandlerImpl();
     com.pengrad.telegrambot.model.Chat chat = mock(com.pengrad.telegrambot.model.Chat.class);
     BotUser botUser = new BotUser(1L, 1L, null, true);
-
-    ApplicationConfig applicationConfig = new ApplicationConfig(
-        "12345",
-        "register",
-        "1",
-        "2",
-        "sorry",
-        "3",
-        "7",
-        "8",
-        "4 ",
-        "^(https?://){1}([\\w\\Q$-_+!*'(),%\\E]+\\.)+(\\w{2,63})(:\\d{1,4})?([\\w\\Q/$-_+!*'(),%\\E]+\\.?[\\w\\Q$-_+!*'(),%\\E={0-5}?&.])*/?$",
-        "6",
-        "",
-        "",
-        ""
-
-    );
-
     @Test
     void processesUnAuthorized() {
         Bot bot = new Bot(
@@ -79,7 +63,7 @@ public class NoCommandHandlerTest {
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.findChat(message.chat().id())).thenReturn(response);
-
+        Mockito.when(applicationConfig.register()).thenReturn("register");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo(
@@ -111,6 +95,7 @@ public class NoCommandHandlerTest {
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.startLinkTracking(botUser.chatId(), linkRequest))
             .thenReturn(new LinkResponse(1L, URI.create("https://stackoverflow.com/search?q=unsupported%20link")));
+        Mockito.when(applicationConfig.done()).thenReturn("4");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo(
@@ -142,6 +127,7 @@ public class NoCommandHandlerTest {
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.stopLinkTracking(botUser.chatId(), linkRequest))
             .thenReturn(new LinkResponse(1L, URI.create("https://stackoverflow.com/search?q=unsupported%20link")));
+        Mockito.when(applicationConfig.done()).thenReturn("4");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo(
@@ -170,6 +156,7 @@ public class NoCommandHandlerTest {
         Mockito.when(message.chat()).thenReturn(chat);
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
+        Mockito.when(applicationConfig.notUnderstand()).thenReturn("sorry");
 
         var result = handler.handle(bot, messageHandler, update);
 

--- a/bot/src/test/java/edu/java/hw1/PenBotTest.java
+++ b/bot/src/test/java/edu/java/hw1/PenBotTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import scala.App;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -36,6 +38,8 @@ public class PenBotTest {
     @Mock Update update = new Update();
 
     @Mock Message message = new Message();
+
+    @Mock ApplicationConfig applicationConfig;
 
     User user = new User(1L);
     com.pengrad.telegrambot.model.Chat chat = mock(com.pengrad.telegrambot.model.Chat.class);
@@ -54,23 +58,6 @@ public class PenBotTest {
             telegramBot,
             Map.of(botUser, chat1),
             isWaiting
-        );
-        ApplicationConfig applicationConfig = new ApplicationConfig(
-            "12345",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "",
-            "",
-            ""
-
         );
         Map<String, CommandHandler> commandHandlers = Map.of(command.name(), new CommandHandler() {
             @Override

--- a/bot/src/test/java/edu/java/hw1/StartHandlerTest.java
+++ b/bot/src/test/java/edu/java/hw1/StartHandlerTest.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,6 +33,8 @@ public class StartHandlerTest {
 
     @Mock Message message = new Message();
     @Mock ScrapperClient scrapperClient;
+
+    @Mock ApplicationConfig applicationConfig;
     HashMap<BotUser, CommandName> isWaiting = new HashMap<>();
     User user = new User(1L);
 
@@ -48,23 +49,6 @@ public class StartHandlerTest {
             new HashMap<>(),
             new HashMap<>()
         );
-        ApplicationConfig applicationConfig = new ApplicationConfig(
-            "12345",
-            "1",
-            "Registered! Hello, dear ",
-            "123123",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "",
-            "",
-            ""
-
-        );
         var handler = new StartHandler(applicationConfig, scrapperClient);
         var response = new ChatResponse(0L);
         Mockito.when(update.message()).thenReturn(message);
@@ -72,7 +56,7 @@ public class StartHandlerTest {
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.findChat(message.chat().id())).thenReturn(response);
-
+        Mockito.when(applicationConfig.registered()).thenReturn("Registered! Hello, dear ");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo(
@@ -94,29 +78,12 @@ public class StartHandlerTest {
             Map.of(botUser, chat1),
             isWaiting
         );
-        ApplicationConfig applicationConfig = new ApplicationConfig(
-            "12345",
-            "1",
-            "1",
-            "1234567",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "1",
-            "",
-            "",
-            ""
-
-        );
         var handler = new StartHandler(applicationConfig, scrapperClient);
         Mockito.when(update.message()).thenReturn(message);
         Mockito.when(message.chat()).thenReturn(chat);
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
-
+        Mockito.when(applicationConfig.alreadyRegistered()).thenReturn("1234567");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo(

--- a/bot/src/test/java/edu/java/hw1/TrackHandlerTest.java
+++ b/bot/src/test/java/edu/java/hw1/TrackHandlerTest.java
@@ -36,28 +36,13 @@ public class TrackHandlerTest {
 
     @Mock ScrapperClient scrapperClient;
 
+    @Mock ApplicationConfig applicationConfig;
+
     User user = new User(1L);
 
     UserMessageHandler messageHandler = new UserMessageHandlerImpl();
     com.pengrad.telegrambot.model.Chat chat = mock(com.pengrad.telegrambot.model.Chat.class);
     BotUser botUser = new BotUser(1L, 1L, null, true);
-    ApplicationConfig applicationConfig = new ApplicationConfig(
-        "12345",
-        "aa",
-        "1",
-        "1",
-        "1",
-        "ttt",
-        "Here you are: ",
-        "You have no links being tracked. Print /track to add a link",
-        "1",
-        "1",
-        "1",
-        "",
-        "",
-        ""
-
-    );
 
     @Test
     void waitsForALink() {
@@ -79,7 +64,7 @@ public class TrackHandlerTest {
         Mockito.when(message.chat()).thenReturn(chat);
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
-
+        Mockito.when(applicationConfig.sendLink()).thenReturn("ttt");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo("ttt");
@@ -99,7 +84,7 @@ public class TrackHandlerTest {
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.findChat(message.chat().id())).thenReturn(response);
-
+        Mockito.when(applicationConfig.register()).thenReturn("aa");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo("aa");

--- a/bot/src/test/java/edu/java/hw1/UnTrackHandlerTest.java
+++ b/bot/src/test/java/edu/java/hw1/UnTrackHandlerTest.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -35,29 +34,12 @@ public class UnTrackHandlerTest {
 
     @Mock Message message = new Message();
     @Mock ScrapperClient scrapperClient;
-
+    @Mock ApplicationConfig applicationConfig;
     User user = new User(1L);
 
     UserMessageHandler messageHandler = new UserMessageHandlerImpl();
     com.pengrad.telegrambot.model.Chat chat = mock(com.pengrad.telegrambot.model.Chat.class);
     BotUser botUser = new BotUser(1L, 1L, null, true);
-    ApplicationConfig applicationConfig = new ApplicationConfig(
-        "12345",
-        "aa",
-        "1",
-        "1",
-        "1",
-        "ttt",
-        "Here you are: ",
-        "You have no links being tracked. Print /track to add a link",
-        "1",
-        "1",
-        "1",
-        "",
-        "",
-        ""
-
-    );
 
     @Test
     void waitsForALink() {
@@ -67,7 +49,7 @@ public class UnTrackHandlerTest {
             botUser.name(),
             new HashSet<>()
         );
-chat1.links().add("https://stackoverflow.com/search?q=unsupported%20link");
+        chat1.links().add("https://stackoverflow.com/search?q=unsupported%20link");
         isWaiting.put(botUser, null);
         var bot = new Bot(
             telegramBot,
@@ -79,7 +61,7 @@ chat1.links().add("https://stackoverflow.com/search?q=unsupported%20link");
         Mockito.when(message.chat()).thenReturn(chat);
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
-
+        Mockito.when(applicationConfig.sendLink()).thenReturn("ttt");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo("ttt");
@@ -99,7 +81,7 @@ chat1.links().add("https://stackoverflow.com/search?q=unsupported%20link");
         Mockito.when(message.chat().id()).thenReturn(1L);
         Mockito.when(message.from()).thenReturn(user);
         Mockito.when(scrapperClient.findChat(message.chat().id())).thenReturn(response);
-
+        Mockito.when(applicationConfig.register()).thenReturn("aa");
         var result = handler.handle(bot, messageHandler, update);
 
         assertThat(result.getParameters().get("text")).isEqualTo("aa");

--- a/bot/src/test/java/edu/java/hw8/KafkaConsumerTest.java
+++ b/bot/src/test/java/edu/java/hw8/KafkaConsumerTest.java
@@ -1,0 +1,65 @@
+package edu.java.hw8;
+
+import edu.java.bot.controller.dto.LinkUpdate;
+import edu.java.bot.service.PenBot;
+import edu.java.bot.service.UpdateKafkaListener;
+import java.net.URI;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest(classes = {UpdateKafkaListener.class, KafkaTestConfiguration.class})
+@Testcontainers
+public class KafkaConsumerTest {
+    @Container
+    public static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"));
+
+    @Autowired
+    public KafkaTemplate<String, LinkUpdate> template;
+
+    @Autowired
+    private UpdateKafkaListener listener;
+
+    @MockBean PenBot penBot;
+
+    @Autowired
+    private KafkaProducer<String, LinkUpdate> producer;
+
+    @Value("${test.topic}")
+    private String topic;
+
+    private final LinkUpdate goodUpdate =
+        new LinkUpdate(1L, URI.create("https://stackoverflow.com"), "12345", new long[0]);
+    private final LinkUpdate badUpdate = null;
+
+    @Test
+    void listenerGetsGoodMessage() {
+        ProducerRecord<String, LinkUpdate> record = new ProducerRecord<>(topic, goodUpdate);
+        assertThat(producer).isNotNull();
+        producer.send(record);
+        listener.listenUpdate(goodUpdate, "", 0);
+        assertThat(listener).isNotNull();
+    }
+    @Test
+    void listenerGetsBadMessage() {
+        ProducerRecord<String, LinkUpdate> record = new ProducerRecord<>(topic, badUpdate);
+        assertThat(producer).isNotNull();
+        producer.send(record);
+        listener.listenUpdate(badUpdate, "", 0);
+
+    }
+
+}

--- a/bot/src/test/java/edu/java/hw8/KafkaTestConfiguration.java
+++ b/bot/src/test/java/edu/java/hw8/KafkaTestConfiguration.java
@@ -1,0 +1,74 @@
+package edu.java.hw8;
+
+import edu.java.bot.controller.dto.LinkUpdate;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaTestConfiguration {
+
+    @Value("${spring.kafka.consumer.concurrency}")
+    private int concurrency;
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, LinkUpdate> updateKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, LinkUpdate> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, LinkUpdate> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigs());
+    }
+
+    @Bean
+    public Map<String, Object> consumerConfigs() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaConsumerTest.kafka.getBootstrapServers());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-bot");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        return props;
+    }
+
+    @Bean
+    public ProducerFactory<String, LinkUpdate> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaConsumerTest.kafka.getBootstrapServers());
+        // more standard configuration
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, LinkUpdate> template() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public KafkaProducer<String, LinkUpdate> producer() {
+        return new KafkaProducer<>(
+            producerFactory().getConfigurationProperties(),
+            new StringSerializer(),
+            new JsonSerializer<>()
+        );
+    }
+}

--- a/bot/src/test/java/edu/java/hw8/Producer.java
+++ b/bot/src/test/java/edu/java/hw8/Producer.java
@@ -1,0 +1,50 @@
+package edu.java.hw8;
+
+import edu.java.bot.controller.dto.LinkUpdate;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+
+public class Producer {
+    private final Logger logger = LogManager.getLogger();
+
+    @Value("${test.topic}")
+    private String topic;
+
+    private final LinkUpdate goodUpdate =
+        new LinkUpdate(1L, URI.create("https://stackoverflow.com"), "12345", new long[0]);
+
+    private final KafkaTemplate<String, LinkUpdate> template;
+
+    public Producer(KafkaTemplate<String, LinkUpdate> template) {
+        this.template = template;
+    }
+
+    public List<LinkUpdate> sendWell() {
+        template
+            .send(
+                topic,
+                1,
+                OffsetDateTime.now().toString(),
+                goodUpdate
+            );
+        logger.info("sent well!");
+        return List.of(goodUpdate);
+    }
+
+    public List<LinkUpdate> sendBadly() {
+        template
+            .send(
+                topic,
+                goodUpdate
+            );
+        logger.info("sent badly!");
+        return List.of(goodUpdate);
+    }
+}

--- a/bot/src/test/resources/application.yml
+++ b/bot/src/test/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  kafka:
+    consumer:
+      auto-offset-reset: earliest
+      group-id: test-bot
+      concurrency: 1
+test:
+  topic: embedded-test

--- a/compose.yml
+++ b/compose.yml
@@ -27,9 +27,100 @@ services:
       - ./migrations:/liquibase/changelog
     networks:
       - backend
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.2.1
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
 
+  kafka1:
+    image: confluentinc/cp-kafka:7.2.1
+    hostname: kafka1
+    container_name: kafka1
+    ports:
+      - "29091:29091"
+    environment:
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:9091,PLAINTEXT_HOST://localhost:29091
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9091,PLAINTEXT_HOST://0.0.0.0:29091
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: 1
+      BOOTSTRAP_SERVERS: kafka1:9091,kafka2:9092,kafka3:9093
+      ZOOKEEPER: zookeeper:2181
+    depends_on:
+      - zookeeper
+    volumes:
+       - kafka1:/var/lib/kafka/data
+  kafka2:
+    image: confluentinc/cp-kafka:7.2.1
+    hostname: kafka2
+    container_name: kafka2
+    ports:
+      - "29092:29092"
+    environment:
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: 2
+      BOOTSTRAP_SERVERS: kafka1:9091,kafka2:9092,kafka3:9093
+      ZOOKEEPER: zookeeper:2181
+    depends_on:
+      - zookeeper
+    volumes:
+      - kafka2:/var/lib/kafka/data
+  kafka3:
+    image: confluentinc/cp-kafka:7.2.1
+    hostname: kafka3
+    container_name: kafka3
+    ports:
+      - "29093:29093"
+    environment:
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:9093,PLAINTEXT_HOST://localhost:29093
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093,PLAINTEXT_HOST://0.0.0.0:29093
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: 3
+      BOOTSTRAP_SERVERS: kafka1:9091,kafka2:9092,kafka3:9093
+      ZOOKEEPER: zookeeper:2181
+    depends_on:
+      - zookeeper
+    volumes:
+      - kafka3:/var/lib/kafka/data
+
+  init-kafka:
+    image: confluentinc/cp-kafka:7.2.1
+    depends_on:
+      - kafka1
+      - kafka2
+      - kafka3
+    entrypoint: [ '/bin/sh', '-c' ]
+    command: |
+      "
+      # blocks until kafka is reachable
+      kafka-topics --bootstrap-server kafka1:9091,kafka2:9092,kafka3:9093 --list
+
+      echo -e 'Creating kafka topics'
+      kafka-topics --bootstrap-server kafka1:9091,kafka2:9092,kafka3:9093 --create --if-not-exists --topic messages.string --replication-factor 2 --partitions 2
+      kafka-topics --bootstrap-server kafka1:9091,kafka2:9092,kafka3:9093 --create --if-not-exists --topic messages.protobuf --replication-factor 2 --partitions 2
+
+      echo -e 'Successfully created the following topics:'
+      kafka-topics --bootstrap-server kafka1:9091,kafka2:9092,kafka3:9093 --list
+      "
 volumes:
   postgresql: { }
+  kafka1:
+    driver: local
+    name: kafka1
+  kafka2:
+    driver: local
+    name: kafka2
+  kafka3:
+    driver: local
+    name: kafka3
 
 networks:
   backend: { }

--- a/scrapper/pom.xml
+++ b/scrapper/pom.xml
@@ -72,6 +72,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.16.0</version>
+        </dependency>
         <!-- Database -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -133,6 +138,11 @@
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -143,7 +153,13 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-
+            <extensions>
+                <extension>
+                    <groupId>kr.motd.maven</groupId>
+                    <artifactId>os-maven-plugin</artifactId>
+                    <version>1.7.0</version>
+                </extension>
+            </extensions>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
@@ -165,6 +181,29 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                        <configuration>
+                            <protoSourceRoot>src/main/resources/proto</protoSourceRoot>
+                            <protocArtifact>
+                                com.google.protobuf:protoc:3.16.0:exe:${os.detected.classifier}
+                            </protocArtifact>
+                            <pluginId>proto-java</pluginId>
+                            <pluginArtifact>
+                                io.grpc:protoc-gen-grpc-java:1.4.0:exe:${os.detected.classifier}
+                            </pluginArtifact>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/scrapper/pom.xml
+++ b/scrapper/pom.xml
@@ -132,6 +132,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -142,6 +152,16 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/scrapper/src/main/java/edu/java/CommandLineRunnerImpl.java
+++ b/scrapper/src/main/java/edu/java/CommandLineRunnerImpl.java
@@ -1,6 +1,8 @@
 package edu.java;
 
 import edu.java.configuration.ApplicationConfig;
+import edu.java.service.ScrapperQueueProducer;
+import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.CommandLineRunner;
@@ -10,11 +12,15 @@ import org.springframework.stereotype.Component;
     Logger logger = LogManager.getLogger();
     private final ApplicationConfig applicationConfig;
 
-    public CommandLineRunnerImpl(ApplicationConfig applicationConfig) {
+    private final ScrapperQueueProducer scrapperQueueProducer;
+
+    public CommandLineRunnerImpl(ApplicationConfig applicationConfig, ScrapperQueueProducer scrapperQueueProducer) {
         this.applicationConfig = applicationConfig;
+        this.scrapperQueueProducer = scrapperQueueProducer;
     }
 
-    @SuppressWarnings({"MagicNumber", "MultipleStringLiterals"}) @Override public void run(String... args) {
+    @SuppressWarnings({"MagicNumber", "MultipleStringLiterals"}) @Override public void run(String... args)
+        throws ExecutionException, InterruptedException {
         logger.info("-> -> -> " + applicationConfig.databaseAccessType());
     }
 }

--- a/scrapper/src/main/java/edu/java/CommandLineRunnerImpl.java
+++ b/scrapper/src/main/java/edu/java/CommandLineRunnerImpl.java
@@ -1,8 +1,6 @@
 package edu.java;
 
 import edu.java.configuration.ApplicationConfig;
-import edu.java.service.ScrapperQueueProducer;
-import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.CommandLineRunner;
@@ -12,15 +10,11 @@ import org.springframework.stereotype.Component;
     Logger logger = LogManager.getLogger();
     private final ApplicationConfig applicationConfig;
 
-    private final ScrapperQueueProducer scrapperQueueProducer;
-
-    public CommandLineRunnerImpl(ApplicationConfig applicationConfig, ScrapperQueueProducer scrapperQueueProducer) {
+    public CommandLineRunnerImpl(ApplicationConfig applicationConfig) {
         this.applicationConfig = applicationConfig;
-        this.scrapperQueueProducer = scrapperQueueProducer;
     }
 
-    @SuppressWarnings({"MagicNumber", "MultipleStringLiterals"}) @Override public void run(String... args)
-        throws ExecutionException, InterruptedException {
+    @SuppressWarnings({"MagicNumber", "MultipleStringLiterals"}) @Override public void run(String... args) {
         logger.info("-> -> -> " + applicationConfig.databaseAccessType());
     }
 }

--- a/scrapper/src/main/java/edu/java/ScrapperApplication.java
+++ b/scrapper/src/main/java/edu/java/ScrapperApplication.java
@@ -2,13 +2,14 @@ package edu.java;
 
 import edu.java.configuration.ApplicationConfig;
 import edu.java.configuration.DataBaseConfig;
+import edu.java.configuration.KafkaConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableConfigurationProperties({ApplicationConfig.class, DataBaseConfig.class})
+@EnableConfigurationProperties({ApplicationConfig.class, DataBaseConfig.class, KafkaConfiguration.class})
 @EnableScheduling
 public class ScrapperApplication {
     public static void main(String[] args) {

--- a/scrapper/src/main/java/edu/java/configuration/ApplicationConfig.java
+++ b/scrapper/src/main/java/edu/java/configuration/ApplicationConfig.java
@@ -23,7 +23,7 @@ public record ApplicationConfig(
     @NotEmpty
     String baseUrlBot,
     AccessType databaseAccessType,
-    boolean useQueue
+    Boolean useQueue
 ) {
     @Bean
     public DefaultConfigurationCustomizer postgresJooqCustomizer() {

--- a/scrapper/src/main/java/edu/java/configuration/ApplicationConfig.java
+++ b/scrapper/src/main/java/edu/java/configuration/ApplicationConfig.java
@@ -22,7 +22,8 @@ public record ApplicationConfig(
     String baseUrlStackOverflow,
     @NotEmpty
     String baseUrlBot,
-    AccessType databaseAccessType
+    AccessType databaseAccessType,
+    boolean useQueue
 ) {
     @Bean
     public DefaultConfigurationCustomizer postgresJooqCustomizer() {

--- a/scrapper/src/main/java/edu/java/configuration/HttpSenderConfiguration.java
+++ b/scrapper/src/main/java/edu/java/configuration/HttpSenderConfiguration.java
@@ -1,0 +1,23 @@
+package edu.java.configuration;
+
+import edu.java.client.BotClient;
+import edu.java.service.ChatService;
+import edu.java.service.LinkUpdater;
+import edu.java.service.LinkUpdaterScheduler;
+import edu.java.service.LinkUpdaterSchedulerHttp;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(prefix = "app", name = "useQueue", havingValue = "false")
+public class HttpSenderConfiguration {
+    @Bean
+    public LinkUpdaterScheduler linkUpdaterScheduler(
+        BotClient botClient,
+        ChatService chatService,
+        LinkUpdater linkUpdater
+    ) {
+        return new LinkUpdaterSchedulerHttp(botClient, linkUpdater, chatService);
+    }
+}

--- a/scrapper/src/main/java/edu/java/configuration/HttpSenderConfiguration.java
+++ b/scrapper/src/main/java/edu/java/configuration/HttpSenderConfiguration.java
@@ -16,8 +16,9 @@ public class HttpSenderConfiguration {
     public LinkUpdaterScheduler linkUpdaterScheduler(
         BotClient botClient,
         ChatService chatService,
-        LinkUpdater linkUpdater
+        LinkUpdater linkUpdater,
+        ApplicationConfig applicationConfig
     ) {
-        return new LinkUpdaterSchedulerHttp(botClient, linkUpdater, chatService);
+        return new LinkUpdaterSchedulerHttp(botClient, linkUpdater, chatService, applicationConfig);
     }
 }

--- a/scrapper/src/main/java/edu/java/configuration/KafkaConfiguration.java
+++ b/scrapper/src/main/java/edu/java/configuration/KafkaConfiguration.java
@@ -1,0 +1,58 @@
+package edu.java.configuration;
+
+import edu.java.client.model.LinkUpdate;
+import jakarta.validation.constraints.NotEmpty;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@ConfigurationProperties("spring.kafka")
+public record KafkaConfiguration(
+    String bootstrapServers,
+    String clientId,
+    @NotEmpty
+    String acksMode,
+    Duration deliveryTimeout,
+    Integer lingerMs,
+    Integer batchSize,
+    Integer maxInFlightPerConnection,
+    Boolean enableIdempotence,
+    String topic
+//    private String securityProtocol;
+//    private String saslMechanism;
+//    private String saslJaasConfig;
+    // String schemaRegistryUrl
+) {
+    @Bean
+    public ProducerFactory<String, LinkUpdate> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, clientId());
+        props.put(ProducerConfig.ACKS_CONFIG, acksMode());
+        props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, (int) deliveryTimeout().toMillis());
+        props.put(ProducerConfig.LINGER_MS_CONFIG, lingerMs());
+        props.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize());
+        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, maxInFlightPerConnection());
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, enableIdempotence());
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, LinkUpdate> kafkaTemplateScrapper(
+        ProducerFactory<String,
+            LinkUpdate> producerFactory
+    ) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+}

--- a/scrapper/src/main/java/edu/java/configuration/KafkaConfiguration.java
+++ b/scrapper/src/main/java/edu/java/configuration/KafkaConfiguration.java
@@ -26,10 +26,6 @@ public record KafkaConfiguration(
     Integer maxInFlightPerConnection,
     Boolean enableIdempotence,
     String topic
-//    private String securityProtocol;
-//    private String saslMechanism;
-//    private String saslJaasConfig;
-    // String schemaRegistryUrl
 ) {
     @Bean
     public ProducerFactory<String, LinkUpdate> producerFactory() {

--- a/scrapper/src/main/java/edu/java/configuration/KafkaSenderConfiguration.java
+++ b/scrapper/src/main/java/edu/java/configuration/KafkaSenderConfiguration.java
@@ -12,8 +12,9 @@ import org.springframework.context.annotation.Configuration;
 public class KafkaSenderConfiguration {
     @Bean
     public LinkUpdaterScheduler linkUpdaterScheduler(
-        ScrapperQueueProducer scrapperQueueProducer
+        ScrapperQueueProducer scrapperQueueProducer,
+        ApplicationConfig applicationConfig
     ) {
-        return new LinkUpdaterSchedulerKafka(scrapperQueueProducer);
+        return new LinkUpdaterSchedulerKafka(scrapperQueueProducer, applicationConfig);
     }
 }

--- a/scrapper/src/main/java/edu/java/configuration/KafkaSenderConfiguration.java
+++ b/scrapper/src/main/java/edu/java/configuration/KafkaSenderConfiguration.java
@@ -1,0 +1,19 @@
+package edu.java.configuration;
+
+import edu.java.service.LinkUpdaterScheduler;
+import edu.java.service.LinkUpdaterSchedulerKafka;
+import edu.java.service.ScrapperQueueProducer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(prefix = "app", name = "useQueue", havingValue = "true")
+public class KafkaSenderConfiguration {
+    @Bean
+    public LinkUpdaterScheduler linkUpdaterScheduler(
+        ScrapperQueueProducer scrapperQueueProducer
+    ) {
+        return new LinkUpdaterSchedulerKafka(scrapperQueueProducer);
+    }
+}

--- a/scrapper/src/main/java/edu/java/serializer/LinkUpdateSerializer.java
+++ b/scrapper/src/main/java/edu/java/serializer/LinkUpdateSerializer.java
@@ -1,0 +1,11 @@
+package edu.java.serializer;
+
+import org.apache.kafka.common.serialization.Serializer;
+import scrapper.LinkUpdateOuterClass;
+
+public class LinkUpdateSerializer implements Serializer<LinkUpdateOuterClass.LinkUpdate> {
+    @Override
+    public byte[] serialize(String s, LinkUpdateOuterClass.LinkUpdate linkUpdate) {
+        return linkUpdate.toByteArray();
+    }
+}

--- a/scrapper/src/main/java/edu/java/service/LinkUpdaterScheduler.java
+++ b/scrapper/src/main/java/edu/java/service/LinkUpdaterScheduler.java
@@ -1,0 +1,8 @@
+package edu.java.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+
+public interface LinkUpdaterScheduler {
+    @Scheduled(fixedDelayString = "#{@scheduler.interval}")
+    void update();
+}

--- a/scrapper/src/main/java/edu/java/service/LinkUpdaterScheduler.java
+++ b/scrapper/src/main/java/edu/java/service/LinkUpdaterScheduler.java
@@ -1,8 +1,5 @@
 package edu.java.service;
 
-import org.springframework.scheduling.annotation.Scheduled;
-
 public interface LinkUpdaterScheduler {
-    @Scheduled(fixedDelayString = "#{@scheduler.interval}")
     void update();
 }

--- a/scrapper/src/main/java/edu/java/service/LinkUpdaterSchedulerHttp.java
+++ b/scrapper/src/main/java/edu/java/service/LinkUpdaterSchedulerHttp.java
@@ -2,6 +2,7 @@ package edu.java.service;
 
 import edu.java.client.BotClient;
 import edu.java.client.model.LinkUpdate;
+import edu.java.configuration.ApplicationConfig;
 import edu.java.domain.model.ChatDao;
 import edu.java.service.model.EventLink;
 import org.apache.logging.log4j.LogManager;
@@ -19,28 +20,32 @@ public class LinkUpdaterSchedulerHttp implements LinkUpdaterScheduler {
     private final LinkUpdater linkUpdater;
 
     private final ChatService chatService;
+    private final ApplicationConfig applicationConfig;
 
     @Autowired
     public LinkUpdaterSchedulerHttp(
-        BotClient botClient,
-        LinkUpdater linkUpdater, ChatService chatService
+            BotClient botClient,
+            LinkUpdater linkUpdater, ChatService chatService, ApplicationConfig applicationConfig
     ) {
         this.botClient = botClient;
         this.linkUpdater = linkUpdater;
         this.chatService = chatService;
+        this.applicationConfig = applicationConfig;
     }
 
     @Override
     @Scheduled(fixedDelayString = "#{@scheduler.interval}")
     public void update() {
-        var links = linkUpdater.update();
-        if (!links.isEmpty()) {
-            var linkUpdates = links.stream().map(this::makeItFromLink).toList();
-            for (LinkUpdate linkUpdate : linkUpdates) {
-                botClient.postUpdate(linkUpdate);
+        if (!applicationConfig.useQueue()) {
+            var links = linkUpdater.update();
+            if (!links.isEmpty()) {
+                var linkUpdates = links.stream().map(this::makeItFromLink).toList();
+                for (LinkUpdate linkUpdate : linkUpdates) {
+                    botClient.postUpdate(linkUpdate);
+                }
+            } else {
+                logger.info("No updates");
             }
-        } else {
-            logger.info("No updates");
         }
     }
 

--- a/scrapper/src/main/java/edu/java/service/LinkUpdaterSchedulerHttp.java
+++ b/scrapper/src/main/java/edu/java/service/LinkUpdaterSchedulerHttp.java
@@ -1,18 +1,17 @@
-package edu.java.client;
+package edu.java.service;
 
+import edu.java.client.BotClient;
 import edu.java.client.model.LinkUpdate;
 import edu.java.domain.model.ChatDao;
-import edu.java.service.ChatService;
-import edu.java.service.LinkUpdater;
 import edu.java.service.model.EventLink;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
-public class LinkUpdaterScheduler {
+@Service
+public class LinkUpdaterSchedulerHttp implements LinkUpdaterScheduler {
     Logger logger = LogManager.getLogger();
 
     private final BotClient botClient;
@@ -22,7 +21,7 @@ public class LinkUpdaterScheduler {
     private final ChatService chatService;
 
     @Autowired
-    public LinkUpdaterScheduler(
+    public LinkUpdaterSchedulerHttp(
         BotClient botClient,
         LinkUpdater linkUpdater, ChatService chatService
     ) {
@@ -31,8 +30,9 @@ public class LinkUpdaterScheduler {
         this.chatService = chatService;
     }
 
+    @Override
     @Scheduled(fixedDelayString = "#{@scheduler.interval}")
-    void update() {
+    public void update() {
         var links = linkUpdater.update();
         if (!links.isEmpty()) {
             var linkUpdates = links.stream().map(this::makeItFromLink).toList();

--- a/scrapper/src/main/java/edu/java/service/LinkUpdaterSchedulerKafka.java
+++ b/scrapper/src/main/java/edu/java/service/LinkUpdaterSchedulerKafka.java
@@ -1,0 +1,29 @@
+package edu.java.service;
+
+import java.util.concurrent.ExecutionException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LinkUpdaterSchedulerKafka implements LinkUpdaterScheduler {
+
+    private final ScrapperQueueProducer scrapperQueueProducer;
+    private final Logger logger = LogManager.getLogger();
+
+    public LinkUpdaterSchedulerKafka(ScrapperQueueProducer scrapperQueueProducer) {
+        this.scrapperQueueProducer = scrapperQueueProducer;
+    }
+
+    @Override
+    @Scheduled(fixedDelayString = "#{@scheduler.interval}")
+    public void update() {
+        try {
+            var result = scrapperQueueProducer.send();
+            logger.info(result);
+        } catch (ExecutionException | InterruptedException e) {
+            logger.error(e.getMessage());
+        }
+    }
+}

--- a/scrapper/src/main/java/edu/java/service/LinkUpdaterSchedulerKafka.java
+++ b/scrapper/src/main/java/edu/java/service/LinkUpdaterSchedulerKafka.java
@@ -1,5 +1,6 @@
 package edu.java.service;
 
+import edu.java.configuration.ApplicationConfig;
 import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,19 +12,23 @@ public class LinkUpdaterSchedulerKafka implements LinkUpdaterScheduler {
 
     private final ScrapperQueueProducer scrapperQueueProducer;
     private final Logger logger = LogManager.getLogger();
+    private final ApplicationConfig applicationConfig;
 
-    public LinkUpdaterSchedulerKafka(ScrapperQueueProducer scrapperQueueProducer) {
+    public LinkUpdaterSchedulerKafka(ScrapperQueueProducer scrapperQueueProducer, ApplicationConfig applicationConfig) {
         this.scrapperQueueProducer = scrapperQueueProducer;
+        this.applicationConfig = applicationConfig;
     }
 
     @Override
     @Scheduled(fixedDelayString = "#{@scheduler.interval}")
     public void update() {
-        try {
-            var result = scrapperQueueProducer.send();
-            logger.info(result);
-        } catch (ExecutionException | InterruptedException e) {
-            logger.error(e.getMessage());
+        if (applicationConfig.useQueue()) {
+            try {
+                var result = scrapperQueueProducer.send();
+                logger.info(result);
+            } catch (ExecutionException | InterruptedException e) {
+                logger.error(e.getMessage());
+            }
         }
     }
 }

--- a/scrapper/src/main/java/edu/java/service/ScrapperQueueProducer.java
+++ b/scrapper/src/main/java/edu/java/service/ScrapperQueueProducer.java
@@ -33,6 +33,11 @@ public class ScrapperQueueProducer {
     }
 
     public List<LinkUpdate> send() throws ExecutionException, InterruptedException {
+//        kafkaTemplateScrapper
+//            .send("messages.string",
+//            //  1,
+//            //OffsetDateTime.now().toString(),
+//                new LinkUpdate(1L, URI.create("https://stackoverflow.com"), "12345", List.of(618490579L), "***"));
         var links = linkUpdater.update();
         if (!links.isEmpty()) {
             var linkUpdates = links.stream().map(this::makeItFromLink).toList();

--- a/scrapper/src/main/java/edu/java/service/ScrapperQueueProducer.java
+++ b/scrapper/src/main/java/edu/java/service/ScrapperQueueProducer.java
@@ -3,6 +3,7 @@ package edu.java.service;
 import edu.java.client.model.LinkUpdate;
 import edu.java.domain.model.ChatDao;
 import edu.java.service.model.EventLink;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
@@ -35,13 +36,15 @@ public class ScrapperQueueProducer {
         var links = linkUpdater.update();
         if (!links.isEmpty()) {
             var linkUpdates = links.stream().map(this::makeItFromLink).toList();
+            var results = new ArrayList<LinkUpdate>();
             for (LinkUpdate li : linkUpdates) {
                 var result = kafkaTemplateScrapper
                     .send("messages.string", 1, li.id() + li.description(), li)
                     .get();
+                results.add(result.getProducerRecord().value());
                 logger.info(result);
             }
-            return linkUpdates;
+            return results;
         }
         return List.of();
     }

--- a/scrapper/src/main/java/edu/java/service/ScrapperQueueProducer.java
+++ b/scrapper/src/main/java/edu/java/service/ScrapperQueueProducer.java
@@ -1,0 +1,58 @@
+package edu.java.service;
+
+import edu.java.client.model.LinkUpdate;
+import edu.java.domain.model.ChatDao;
+import edu.java.service.model.EventLink;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ScrapperQueueProducer {
+    private final LinkUpdater linkUpdater;
+    private final ChatService chatService;
+
+    private final Logger logger = LogManager.getLogger();
+
+    private final KafkaTemplate<String, LinkUpdate> kafkaTemplateScrapper;
+
+    @Autowired
+    public ScrapperQueueProducer(
+        LinkUpdater linkUpdater,
+        ChatService chatService,
+        KafkaTemplate<String, LinkUpdate> kafkaTemplate
+    ) {
+        this.linkUpdater = linkUpdater;
+        this.chatService = chatService;
+        this.kafkaTemplateScrapper = kafkaTemplate;
+    }
+
+    public List<LinkUpdate> send() throws ExecutionException, InterruptedException {
+        var links = linkUpdater.update();
+        if (!links.isEmpty()) {
+            var linkUpdates = links.stream().map(this::makeItFromLink).toList();
+            for (LinkUpdate li : linkUpdates) {
+                var result = kafkaTemplateScrapper
+                    .send("messages.string", 1, li.id() + li.description(), li)
+                    .get();
+                logger.info(result);
+            }
+            return linkUpdates;
+        }
+        return List.of();
+    }
+
+    private LinkUpdate makeItFromLink(EventLink eventLink) {
+        return new LinkUpdate(
+            eventLink.getLink().getId(),
+            eventLink.getLink().getUri(),
+            eventLink.getEvent().getDescription(),
+            chatService.findAllChatsWithLink(eventLink.getLink().getUri()).stream().map(ChatDao::getId).toList(),
+            eventLink.getEvent().getDescription()
+        );
+    }
+}

--- a/scrapper/src/main/java/edu/java/service/ScrapperQueueProducer.java
+++ b/scrapper/src/main/java/edu/java/service/ScrapperQueueProducer.java
@@ -33,11 +33,15 @@ public class ScrapperQueueProducer {
     }
 
     public List<LinkUpdate> send() throws ExecutionException, InterruptedException {
+
+        // bad message example for fast check >>
+
 //        kafkaTemplateScrapper
 //            .send("messages.string",
 //            //  1,
 //            //OffsetDateTime.now().toString(),
-//                new LinkUpdate(1L, URI.create("https://stackoverflow.com"), "12345", List.of(618490579L), "***"));
+//                new LinkUpdate(1L, URI.create("https://stackoverflow.com"), "12345", List.of(618490579L), "hello exception"));
+
         var links = linkUpdater.update();
         if (!links.isEmpty()) {
             var linkUpdates = links.stream().map(this::makeItFromLink).toList();

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -7,6 +7,7 @@ app:
   baseUrlStackOverflow: "https://api.stackexchange.com/2.3"
   baseUrlBot: "http://localhost:8090"
   database-access-type: jpa
+  useQueue: true
 spring:
   application:
     name: scrapper
@@ -15,7 +16,15 @@ spring:
     username: postgres
     password: postgres
     driverClassName: org.postgresql.Driver
-
+  kafka:
+    bootstrapServers: localhost:29091
+    clientId: scrapper
+    acksMode: all
+    deliveryTimeout: 60s
+    lingerMs: 12_000
+    batchSize: 100_000
+    maxInFlightPerConnection: 5
+    enableIdempotence: true # to handle specific retry errors
 
 server:
   port: 8080

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -1,13 +1,13 @@
 app:
   scheduler:
     enable: true
-    interval: 90000
-    force-check-delay: 90000
+    interval: 20000
+    force-check-delay: 20000
   baseUrlGitHub: "https://api.github.com"
   baseUrlStackOverflow: "https://api.stackexchange.com/2.3"
   baseUrlBot: "http://localhost:8090"
   database-access-type: jpa
-  useQueue: true
+  use-queue: true
 spring:
   application:
     name: scrapper

--- a/scrapper/src/main/resources/proto/linkUpdate.proto
+++ b/scrapper/src/main/resources/proto/linkUpdate.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package scrapper;
+
+message LinkUpdate {
+    int64 id = 1;
+    string url = 2;
+    repeated int64 tgChatIds = 3;
+    string description = 4;
+    string eventDescription = 5;
+}

--- a/scrapper/src/test/java/edu/java/GitHubClientTest.java
+++ b/scrapper/src/test/java/edu/java/GitHubClientTest.java
@@ -3,6 +3,8 @@ package edu.java;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import edu.java.client.GitHubClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -17,6 +19,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 
 @WireMockTest
 public class GitHubClientTest {
+    private static final Logger LOGGER = LogManager.getLogger();
     @RegisterExtension
     static WireMockExtension wm = WireMockExtension.newInstance()
         .options(wireMockConfig().port(8080))
@@ -44,7 +47,7 @@ public class GitHubClientTest {
         try {
             gh.getResponse("Marijarin", "tocook");
         } catch (IllegalStateException e) {
-            System.out.println(e.getMessage());
+            LOGGER.error(e.getMessage());
         }
         wm.verify(getRequestedFor(urlPathMatching("/repos/.*")));
     }

--- a/scrapper/src/test/java/edu/java/JdbcLinkUpdaterTest.java
+++ b/scrapper/src/test/java/edu/java/JdbcLinkUpdaterTest.java
@@ -13,6 +13,8 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JdbcLinkUpdaterTest extends IntegrationTest{
     private final JdbcLinkService linkService;
     private final JdbcLinkUpdater linkUpdater;
-
+    private static final Logger LOGGER = LogManager.getLogger();
     @Autowired
     public JdbcLinkUpdaterTest(JdbcLinkService linkService, JdbcLinkUpdater linkUpdater) {
         this.linkService = linkService;
@@ -61,7 +63,7 @@ public class JdbcLinkUpdaterTest extends IntegrationTest{
             eventList = (ArrayList<EventLink>) linkUpdater
                 .updateFromGithub(List.of(linkDao));
         } catch (IllegalStateException e) {
-            System.out.println(e.getMessage());
+            LOGGER.error(e.getMessage());
         }
         assertThat(eventList.getFirst().getEvent().getDescription())
             .isEqualTo(EventName.getEventMap().get("PushEvent")
@@ -86,7 +88,7 @@ public class JdbcLinkUpdaterTest extends IntegrationTest{
             eventList = (ArrayList<EventLink>) linkUpdater
                 .updateFromStackOverFlow(List.of(linkDao));
         } catch (IllegalStateException e) {
-            System.out.println(e.getMessage());
+            LOGGER.error(e.getMessage());
         }
         assertThat(eventList.getFirst().getEvent().getDescription())
             .isEqualTo(EventName.getEventMap().get("answer")
@@ -111,7 +113,7 @@ public class JdbcLinkUpdaterTest extends IntegrationTest{
             eventList = (ArrayList<EventLink>) linkUpdater
                 .updateFromStackOverFlow(List.of(linkDao));
         } catch (IllegalStateException e) {
-            System.out.println(e.getMessage());
+            LOGGER.error(e.getMessage());
         }
         assertThat(eventList.isEmpty()).isTrue();
         wm.verify(getRequestedFor(urlPathMatching("/questions/1/timeline.*")));

--- a/scrapper/src/test/java/edu/java/JooqLinkUpdaterTest.java
+++ b/scrapper/src/test/java/edu/java/JooqLinkUpdaterTest.java
@@ -13,6 +13,8 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JooqLinkUpdaterTest extends IntegrationTest {
     private final JooqLinkService linkService;
     private final JooqLinkUpdater linkUpdater;
-
+    private static final Logger LOGGER = LogManager.getLogger();
     @Autowired
     public JooqLinkUpdaterTest(JooqLinkService linkService, JooqLinkUpdater linkUpdater) {
         this.linkService = linkService;
@@ -62,7 +64,7 @@ public class JooqLinkUpdaterTest extends IntegrationTest {
             eventList = (ArrayList<EventLink>) linkUpdater
                 .updateFromGithub(List.of(linkDao));
         } catch (IllegalStateException e) {
-            System.out.println(e.getMessage());
+            LOGGER.error(e.getMessage());
         }
         assertThat(eventList.getFirst().getEvent().getDescription())
             .isEqualTo(EventName.getEventMap().get("CreateEvent")
@@ -87,7 +89,7 @@ public class JooqLinkUpdaterTest extends IntegrationTest {
             eventList = (ArrayList<EventLink>) linkUpdater
                 .updateFromStackOverFlow(List.of(linkDao));
         } catch (IllegalStateException e) {
-            System.out.println(e.getMessage());
+            LOGGER.error(e.getMessage());
         }
         assertThat(eventList.getFirst().getEvent().getDescription())
             .isEqualTo(EventName.getEventMap().get("answer")

--- a/scrapper/src/test/java/edu/java/JpaUpdaterServiceTest.java
+++ b/scrapper/src/test/java/edu/java/JpaUpdaterServiceTest.java
@@ -14,6 +14,8 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +37,7 @@ public class JpaUpdaterServiceTest extends IntegrationTest {
     @Autowired JpaLinkService linkService;
     @Autowired JpaLinkUpdater linkUpdater;
 
+    private static final Logger LOGGER = LogManager.getLogger();
     @RegisterExtension
     static WireMockExtension wm = WireMockExtension.newInstance()
         .options(wireMockConfig().port(8080))
@@ -56,7 +59,7 @@ public class JpaUpdaterServiceTest extends IntegrationTest {
             eventList = (ArrayList<EventLink>) linkUpdater
                 .updateFromGithub(List.of(linkDao));
         } catch (IllegalStateException e) {
-            System.out.println(e.getMessage());
+            LOGGER.error(e.getMessage());
         }
         assertThat(eventList.getFirst().getEvent().getDescription())
             .isEqualTo(EventName.getEventMap().get("IssueCommentEvent")
@@ -81,7 +84,7 @@ public class JpaUpdaterServiceTest extends IntegrationTest {
             eventList = (ArrayList<EventLink>) linkUpdater
                 .updateFromStackOverFlow(List.of(linkDao));
         } catch (IllegalStateException e) {
-            System.out.println(e.getMessage());
+            LOGGER.error(e.getMessage());
         }
         assertThat(eventList.getFirst().getEvent().getDescription())
             .isEqualTo(EventName.getEventMap().get("comment")

--- a/scrapper/src/test/java/edu/java/StackOverflowClientTest.java
+++ b/scrapper/src/test/java/edu/java/StackOverflowClientTest.java
@@ -3,6 +3,8 @@ package edu.java;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import edu.java.client.StackOverflowClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -17,6 +19,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 
 @WireMockTest
 public class StackOverflowClientTest {
+    private static final Logger LOGGER = LogManager.getLogger();
     @RegisterExtension
     static WireMockExtension wm = WireMockExtension.newInstance()
         .options(wireMockConfig().port(8080))
@@ -44,7 +47,7 @@ public class StackOverflowClientTest {
         try {
             sof.getResponse("1");
         } catch (IllegalStateException e) {
-            System.out.println(e.getMessage());
+            LOGGER.error(e.getMessage());
         }
         wm.verify(getRequestedFor(urlPathMatching("/questions/1/timeline.*")));
     }

--- a/scrapper/src/test/resources/json/gh-create.json
+++ b/scrapper/src/test/resources/json/gh-create.json
@@ -2,6 +2,6 @@
     {
         "id": "1",
         "type": "CreateEvent",
-        "created_at": "2024-03-25T01:28:01Z"
+        "created_at": "2024-04-25T01:28:01Z"
     }
 ]

--- a/scrapper/src/test/resources/json/gh-create.json
+++ b/scrapper/src/test/resources/json/gh-create.json
@@ -2,6 +2,6 @@
     {
         "id": "1",
         "type": "CreateEvent",
-        "created_at": "2024-04-25T01:28:01Z"
+        "created_at": "2024-06-25T01:28:01Z"
     }
 ]

--- a/scrapper/src/test/resources/json/gh-issue.json
+++ b/scrapper/src/test/resources/json/gh-issue.json
@@ -2,6 +2,6 @@
     {
         "id": "1",
         "type": "IssueCommentEvent",
-        "created_at": "2024-03-25T01:28:01Z"
+        "created_at": "2024-04-25T01:28:01Z"
     }
 ]

--- a/scrapper/src/test/resources/json/gh-issue.json
+++ b/scrapper/src/test/resources/json/gh-issue.json
@@ -2,6 +2,6 @@
     {
         "id": "1",
         "type": "IssueCommentEvent",
-        "created_at": "2024-04-25T01:28:01Z"
+        "created_at": "2024-06-25T01:28:01Z"
     }
 ]

--- a/scrapper/src/test/resources/json/gh-push.json
+++ b/scrapper/src/test/resources/json/gh-push.json
@@ -2,6 +2,6 @@
     {
         "id": "1",
         "type": "PushEvent",
-        "created_at": "2024-03-25T01:28:01Z"
+        "created_at": "2024-04-25T01:28:01Z"
     }
 ]

--- a/scrapper/src/test/resources/json/gh-push.json
+++ b/scrapper/src/test/resources/json/gh-push.json
@@ -2,6 +2,6 @@
     {
         "id": "1",
         "type": "PushEvent",
-        "created_at": "2024-04-25T01:28:01Z"
+        "created_at": "2024-06-25T01:28:01Z"
     }
 ]

--- a/scrapper/src/test/resources/json/sof-answer.json
+++ b/scrapper/src/test/resources/json/sof-answer.json
@@ -10,7 +10,7 @@
                 "display_name": "user",
                 "link": "https://stackoverflow.com/users/2/user"
             },
-            "creation_date": 1711306800,
+            "creation_date": 1811306800,
             "down_vote_count": 0,
             "up_vote_count": 1,
             "post_id": 1,

--- a/scrapper/src/test/resources/json/sof-comment.json
+++ b/scrapper/src/test/resources/json/sof-comment.json
@@ -10,7 +10,7 @@
                 "display_name": "user",
                 "link": "https://stackoverflow.com/users/2/user"
             },
-            "creation_date": 1711306800,
+            "creation_date": 1811306800,
             "down_vote_count": 0,
             "up_vote_count": 1,
             "post_id": 1,


### PR DESCRIPTION
Страшные объявления в прошлых тестах исправила)

По поводу DLQ - создается через RetryableTopic. Но есть проблема, не поняла, как решить: хотела ошибки выводить через логи, создала ErrorHandler, который обрабатывает ошибки от Listener, но потом он проглатывает  похожие ошибочные сообщения и они не идут в DLT.
К сожалению, не сразу дошло, что в общем требовалось только написать правильно сконфигурированного продюсера и вставить его в RetryableTopic :) Думала, что @DltHandler всем этим занимается, а это немного другое. Вот в чем печаль, когда там что-то само генерируется под капотом)

Еще хотела сделать тест с @TestConfiguration в виде статического класса внутреннего, но почему-то не подтягивался сервер из контейнера, сделала просто с @ Configuration.

Еще там присутствует protobuf, но у меня URI вроде не сериализовалось как я хотела просто в строку (если правильно поняла), а потом я побоялась зависнуть и не успеть остальное, сделала  json-сериализацию. Но вот хотела узнать, вот [тут](https://stackoverflow.com/questions/72542045/grpc-proto-buff-url-uri-type) - stackoverflow - разумное предложение так составить схему для URI если использовать protobuf ?

Еще после добавления RetryableTopic у меня не сразу бот подключается к Кафке, я так поняла, но потом ему удается, иногда после исключения, что не может сконфигурировать топики. Это ошибка какая-то или в пределях нормального (скрин). Боюсь что-то менять) оказывается, от небольших изменений может все отвалиться)
![image](https://github.com/Marijarin/tin_back_hws/assets/106971617/1eaa6581-eb92-4744-b647-2f8b73824403)
